### PR TITLE
Enabling rinkeby and getting token data from dex-js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+venv

--- a/README.md
+++ b/README.md
@@ -58,4 +58,8 @@ example runs:
 
 - `python plot_order_graph.py --jsonFile data/dfusion_input.json`
 - `python plot_solution_graph.py data/kraken_solution.json`
-- `python plot_orderbook_tokenpair.py PAX WETH
+- `python plot_orderbook_tokenpair.py PAX WETH`
+
+additionally, the network ('mainnet' or 'rinkeby') for the token pair can be defined as well via the network parameter:
+
+- `python plot_orderbook_tokenpair.py PAX WETH --network=rinkeby`

--- a/TokenInfo.py
+++ b/TokenInfo.py
@@ -1,46 +1,8 @@
-"""File containing token names and decimals."""
-
-TOKEN_NAMES = {
-    'T0000': 'OWL',
-    'T0001': 'WETH',
-    'T0002': 'USDT',
-    'T0003': 'TUSD',
-    'T0004': 'USDC',
-    'T0005': 'PAX',
-    'T0006': 'GUSD',
-    'T0007': 'DAI',
-    'T0008': 'sETH',
-    'T0009': 'sUSD',
-    'T0010': 'sBTC',
-    'T0011': 'WBTC',
-    'T0012': 'SAI',
-    'T0013': 'cDAI',
-    'T0014': 'aDAI',
-    'T0015': 'SNX',
-    'T0016': 'CHAI',
-    'T0017': 'PAXG',
-    'T0018': 'GNO'
-}
+import requests
+import json
 
 
-TOKEN_DECIMALS = {
-    'T0000': 18,
-    'T0001': 18,
-    'T0002': 6,
-    'T0003': 18,
-    'T0004': 6,
-    'T0005': 18,
-    'T0006': 2,
-    'T0007': 18,
-    'T0008': 18,
-    'T0009': 18,
-    'T0010': 18,
-    'T0011': 8,
-    'T0012': 18,
-    'T0013': 8,
-    'T0014': 18,
-    'T0015': 18,
-    'T0016': 18,
-    'T0017': 18,
-    'T0018': 18
-}
+def get_token_data():
+    token_list_url = "https://raw.githubusercontent.com/gnosis/dex-js/master/src/tokenList.json"
+    r = requests.get(token_list_url)
+    return r.json()

--- a/contract_reader.py
+++ b/contract_reader.py
@@ -5,19 +5,24 @@ from decimal import Decimal
 import logging
 
 
-# Specify Infura credentials (currently: Martins access key).
-infura_url = "https://node.mainnet.gnosisdev.com"
-web3 = Web3(Web3.HTTPProvider(infura_url))
-
-
 # Set smart contract info.
 abi = '[{"constant":true,"inputs":[],"name":"IMPROVEMENT_DENOMINATOR","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"getSecondsRemainingInBatch","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"getEncodedOrders","outputs":[{"name":"elements","type":"bytes"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"buyToken","type":"uint16"},{"name":"sellToken","type":"uint16"},{"name":"validUntil","type":"uint32"},{"name":"buyAmount","type":"uint128"},{"name":"sellAmount","type":"uint128"}],"name":"placeOrder","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[{"name":"batchId","type":"uint32"},{"name":"claimedObjectiveValue","type":"uint256"},{"name":"owners","type":"address[]"},{"name":"orderIds","type":"uint16[]"},{"name":"buyVolumes","type":"uint128[]"},{"name":"prices","type":"uint128[]"},{"name":"tokenIdsForPrice","type":"uint16[]"}],"name":"submitSolution","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[{"name":"id","type":"uint16"}],"name":"tokenIdToAddressMap","outputs":[{"name":"","type":"address"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"token","type":"address"},{"name":"amount","type":"uint256"}],"name":"requestWithdraw","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"FEE_FOR_LISTING_TOKEN_IN_OWL","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[{"name":"previousPageUser","type":"address"},{"name":"pageSize","type":"uint16"}],"name":"getUsersPaginated","outputs":[{"name":"users","type":"bytes"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"token","type":"address"},{"name":"amount","type":"uint256"}],"name":"deposit","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[{"name":"orderIds","type":"uint16[]"}],"name":"cancelOrders","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"AMOUNT_MINIMUM","outputs":[{"name":"","type":"uint128"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"feeToken","outputs":[{"name":"","type":"address"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"buyTokens","type":"uint16[]"},{"name":"sellTokens","type":"uint16[]"},{"name":"validFroms","type":"uint32[]"},{"name":"validUntils","type":"uint32[]"},{"name":"buyAmounts","type":"uint128[]"},{"name":"sellAmounts","type":"uint128[]"}],"name":"placeValidFromOrders","outputs":[{"name":"orderIds","type":"uint16[]"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[{"name":"","type":"uint16"}],"name":"currentPrices","outputs":[{"name":"","type":"uint128"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[{"name":"user","type":"address"}],"name":"getEncodedUserOrders","outputs":[{"name":"elements","type":"bytes"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[{"name":"","type":"address"},{"name":"","type":"uint256"}],"name":"orders","outputs":[{"name":"buyToken","type":"uint16"},{"name":"sellToken","type":"uint16"},{"name":"validFrom","type":"uint32"},{"name":"validUntil","type":"uint32"},{"name":"priceNumerator","type":"uint128"},{"name":"priceDenominator","type":"uint128"},{"name":"usedAmount","type":"uint128"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"UNLIMITED_ORDER_AMOUNT","outputs":[{"name":"","type":"uint128"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"numTokens","outputs":[{"name":"","type":"uint16"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[{"name":"","type":"address"},{"name":"","type":"address"}],"name":"lastCreditBatchId","outputs":[{"name":"","type":"uint32"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[{"name":"previousPageUser","type":"address"},{"name":"previousPageUserOffset","type":"uint16"},{"name":"pageSize","type":"uint16"}],"name":"getEncodedUsersPaginated","outputs":[{"name":"elements","type":"bytes"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[{"name":"addr","type":"address"}],"name":"hasToken","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"latestSolution","outputs":[{"name":"batchId","type":"uint32"},{"name":"solutionSubmitter","type":"address"},{"name":"feeReward","type":"uint256"},{"name":"objectiveValue","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[{"name":"user","type":"address"},{"name":"token","type":"address"}],"name":"getPendingDeposit","outputs":[{"name":"","type":"uint256"},{"name":"","type":"uint32"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"cancellations","type":"uint16[]"},{"name":"buyTokens","type":"uint16[]"},{"name":"sellTokens","type":"uint16[]"},{"name":"validFroms","type":"uint32[]"},{"name":"validUntils","type":"uint32[]"},{"name":"buyAmounts","type":"uint128[]"},{"name":"sellAmounts","type":"uint128[]"}],"name":"replaceOrders","outputs":[{"name":"","type":"uint16[]"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[{"name":"user","type":"address"},{"name":"token","type":"address"}],"name":"getPendingWithdraw","outputs":[{"name":"","type":"uint256"},{"name":"","type":"uint32"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[{"name":"batchId","type":"uint32"}],"name":"acceptingSolutions","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"token","type":"address"}],"name":"addToken","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[{"name":"user","type":"address"},{"name":"token","type":"address"}],"name":"getBalance","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"FEE_DENOMINATOR","outputs":[{"name":"","type":"uint128"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"ENCODED_AUCTION_ELEMENT_WIDTH","outputs":[{"name":"","type":"uint128"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"BATCH_TIME","outputs":[{"name":"","type":"uint32"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"getCurrentBatchId","outputs":[{"name":"","type":"uint32"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[{"name":"user","type":"address"},{"name":"offset","type":"uint16"},{"name":"pageSize","type":"uint16"}],"name":"getEncodedUserOrdersPaginated","outputs":[{"name":"elements","type":"bytes"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[{"name":"addr","type":"address"}],"name":"tokenAddressToIdMap","outputs":[{"name":"","type":"uint16"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"token","type":"address"},{"name":"amount","type":"uint256"},{"name":"batchId","type":"uint32"}],"name":"requestFutureWithdraw","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[{"name":"user","type":"address"},{"name":"token","type":"address"}],"name":"hasValidWithdrawRequest","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"MAX_TOKENS","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"user","type":"address"},{"name":"token","type":"address"}],"name":"withdraw","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"MAX_TOUCHED_ORDERS","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"getCurrentObjectiveValue","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"inputs":[{"name":"maxTokens","type":"uint256"},{"name":"_feeToken","type":"address"}],"payable":false,"stateMutability":"nonpayable","type":"constructor"},{"anonymous":false,"inputs":[{"indexed":true,"name":"owner","type":"address"},{"indexed":false,"name":"index","type":"uint16"},{"indexed":true,"name":"buyToken","type":"uint16"},{"indexed":true,"name":"sellToken","type":"uint16"},{"indexed":false,"name":"validFrom","type":"uint32"},{"indexed":false,"name":"validUntil","type":"uint32"},{"indexed":false,"name":"priceNumerator","type":"uint128"},{"indexed":false,"name":"priceDenominator","type":"uint128"}],"name":"OrderPlacement","type":"event"},{"anonymous":false,"inputs":[{"indexed":false,"name":"token","type":"address"},{"indexed":false,"name":"id","type":"uint16"}],"name":"TokenListing","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"owner","type":"address"},{"indexed":false,"name":"id","type":"uint16"}],"name":"OrderCancellation","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"owner","type":"address"},{"indexed":false,"name":"id","type":"uint16"}],"name":"OrderDeletion","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"owner","type":"address"},{"indexed":true,"name":"orderId","type":"uint16"},{"indexed":true,"name":"sellToken","type":"uint16"},{"indexed":false,"name":"buyToken","type":"uint16"},{"indexed":false,"name":"executedSellAmount","type":"uint128"},{"indexed":false,"name":"executedBuyAmount","type":"uint128"}],"name":"Trade","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"owner","type":"address"},{"indexed":true,"name":"orderId","type":"uint16"},{"indexed":true,"name":"sellToken","type":"uint16"},{"indexed":false,"name":"buyToken","type":"uint16"},{"indexed":false,"name":"executedSellAmount","type":"uint128"},{"indexed":false,"name":"executedBuyAmount","type":"uint128"}],"name":"TradeReversion","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"submitter","type":"address"},{"indexed":false,"name":"utility","type":"uint256"},{"indexed":false,"name":"disregardedUtility","type":"uint256"},{"indexed":false,"name":"burntFees","type":"uint256"},{"indexed":false,"name":"lastAuctionBurntFees","type":"uint256"},{"indexed":false,"name":"prices","type":"uint128[]"},{"indexed":false,"name":"tokenIdsForPrice","type":"uint16[]"}],"name":"SolutionSubmission","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"user","type":"address"},{"indexed":true,"name":"token","type":"address"},{"indexed":false,"name":"amount","type":"uint256"},{"indexed":false,"name":"batchId","type":"uint32"}],"name":"Deposit","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"user","type":"address"},{"indexed":true,"name":"token","type":"address"},{"indexed":false,"name":"amount","type":"uint256"},{"indexed":false,"name":"batchId","type":"uint32"}],"name":"WithdrawRequest","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"user","type":"address"},{"indexed":true,"name":"token","type":"address"},{"indexed":false,"name":"amount","type":"uint256"}],"name":"Withdraw","type":"event"}]'
-address = "0x6F400810b62df8E13fded51bE75fF5393eaa841F"
-contract = web3.eth.contract(address=address, abi=abi)
 
 
-def get_current_batch_id():
+def init_contract(network='mainnet'):
+    # Specify Infura credentials
+    node_url = "https://"+network+".infura.io/v3/9408f47dedf04716a03ef994182cf150"
+    networkSwitcher = {
+        'mainnet': "0x6F400810b62df8E13fded51bE75fF5393eaa841F",
+        'rinkeby': "0xC576eA7bd102F7E476368a5E98FA455d1Ea34dE2",
+    }
+    web3 = Web3(Web3.HTTPProvider(node_url))
+    return web3.eth.contract(address=networkSwitcher.get(network, "not a valid network"), abi=abi)
+
+
+def get_current_batch_id(network='mainnet'):
     """Get ID of current batch."""
+    contract = init_contract(network)
     return contract.functions.getCurrentBatchId().call()
 
 
@@ -82,23 +87,23 @@ def decode_orders(orders_encoded):
     return orders_decoded
 
 
-def get_current_orderbook():
+def get_current_orderbook(network='mainnet'):
     """Get all currently valid orders from smart contract.
 
     Returns:
         A list of all orders.
 
     """
-    orders = get_orderbook()
+    orders = get_orderbook(network)
 
     # Skip orders that are no longer or not yet valid.
-    batch_id = get_current_batch_id()
+    batch_id = get_current_batch_id(network)
     orders = list(filter(lambda order: order['validUntil'] >= batch_id
                          and order['validFrom'] <= batch_id, orders))
     return orders
 
 
-def get_orderbook():
+def get_orderbook(network='mainnet'):
     """Get all order data from smart contract.
 
     Returns:
@@ -117,7 +122,7 @@ def get_orderbook():
     while last_page_size == page_size:
 
         orders_decoded_raw = decode_orders(
-            contract.functions.getEncodedUsersPaginated(
+            init_contract(network).functions.getEncodedUsersPaginated(
                 Web3.toChecksumAddress(current_user),
                 current_offset, page_size).call())
 
@@ -166,7 +171,7 @@ def get_orderbook():
 
 
 def get_account_balances(tokens: List[str],
-                         orders: List[Dict]) -> Dict[str, Dict[str, str]]:
+                         orders: List[Dict], network='mainnet') -> Dict[str, Dict[str, str]]:
     """Get account balances of the sell tokens of all orders.
 
     Args:
@@ -178,6 +183,8 @@ def get_account_balances(tokens: List[str],
 
     """
     # Get token adresses first.
+    contract = init_contract(
+        network)
     token_adresses = {}
     for t in tokens:
         tID = int(t.replace('T', ''))

--- a/contract_reader.py
+++ b/contract_reader.py
@@ -117,12 +117,13 @@ def get_orderbook(network='mainnet'):
     current_user = '0x0000000000000000000000000000000000000000'
     current_offset = 0
     last_page_size = page_size
+    contract = init_contract(network)
 
     # Read unprocessed order data.
     while last_page_size == page_size:
 
         orders_decoded_raw = decode_orders(
-            init_contract(network).functions.getEncodedUsersPaginated(
+            contract.functions.getEncodedUsersPaginated(
                 Web3.toChecksumAddress(current_user),
                 current_offset, page_size).call())
 
@@ -171,7 +172,8 @@ def get_orderbook(network='mainnet'):
 
 
 def get_account_balances(tokens: List[str],
-                         orders: List[Dict], network='mainnet') -> Dict[str, Dict[str, str]]:
+                         orders: List[Dict],
+                         network='mainnet') -> Dict[str, Dict[str, str]]:
     """Get account balances of the sell tokens of all orders.
 
     Args:
@@ -183,8 +185,7 @@ def get_account_balances(tokens: List[str],
 
     """
     # Get token adresses first.
-    contract = init_contract(
-        network)
+    contract = init_contract(network)
     token_adresses = {}
     for t in tokens:
         tID = int(t.replace('T', ''))

--- a/generate_plot_for_all_pairs.py
+++ b/generate_plot_for_all_pairs.py
@@ -26,6 +26,13 @@ if __name__ == "__main__":
         type=str,
         help="A JSON input file containing a batch auction instance.")
 
+    parser.add_argument(
+        '--network',
+        type=str,
+        choices=['mainnet', 'rinkeby'],
+        default='mainnet',
+        help="Choose one network (mainnet or rinkeby)")
+
     args = parser.parse_args()
 
     if args.jsonFile is not None:
@@ -34,7 +41,7 @@ if __name__ == "__main__":
         inst = util.read_instance_from_file(args.jsonFile)
     else:
         # Get instance from blockchain.
-        inst = util.read_instance_from_blockchain()
+        inst = util.read_instance_from_blockchain(args.network)
 
     # Get max token ID
     # Todo: This can be automatized, but then also the TokenInfo.py must be generated automatically

--- a/generate_plot_for_all_pairs.py
+++ b/generate_plot_for_all_pairs.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import argparse
 from multiprocessing import Pool, cpu_count
 from functools import partial
-
+from TokenInfo import get_token_data
 
 if __name__ == "__main__":
     """Main function."""
@@ -52,7 +52,8 @@ if __name__ == "__main__":
     ]
 
     def plot(args):
-        generate_plot(*args, inst['orders'], output_dir, False, auto_open=False)
+        generate_plot(*args, inst['orders'],
+                      output_dir, False, auto_open=False)
 
     num_cores = cpu_count()
     with Pool(num_cores) as pool:

--- a/plot_order_graph.py
+++ b/plot_order_graph.py
@@ -85,7 +85,14 @@ if __name__ == "__main__":
         type=str,
         help="A JSON input file containing a batch auction instance.")
 
+    parser.add_argument(
+        '--network',
+        dest='network',
+        type=str,
+        help="Choose one network (mainnet or rinkeby)")
+
     args = parser.parse_args()
+    parser.set_defaults(network='mainnet')
 
     if args.jsonFile is not None:
         # Read input JSON.
@@ -95,7 +102,7 @@ if __name__ == "__main__":
     else:
         # Get instance from blockchain.
         output_dir = './'
-        inst = util.read_instance_from_blockchain()
+        inst = util.read_instance_from_blockchain(args.network)
 
     # Get number of orders per token pair.
     assert 'orders' in inst

--- a/plot_order_graph.py
+++ b/plot_order_graph.py
@@ -87,12 +87,12 @@ if __name__ == "__main__":
 
     parser.add_argument(
         '--network',
-        dest='network',
         type=str,
+        choices=['mainnet', 'rinkeby'],
+        default='mainnet',
         help="Choose one network (mainnet or rinkeby)")
 
     args = parser.parse_args()
-    parser.set_defaults(network='mainnet')
 
     if args.jsonFile is not None:
         # Read input JSON.

--- a/plot_orderbook_tokenpair.py
+++ b/plot_orderbook_tokenpair.py
@@ -45,13 +45,16 @@ def generate_plot(t1: str,
             continue
 
         # Get amounts scaled to human-readable values.
-        sell_amount = Decimal(o['sellAmount']) / Decimal(10**util.get_token_decimals(tS))
-        buy_amount = Decimal(o['buyAmount']) / Decimal(10**util.get_token_decimals(tB))
+        sell_amount = Decimal(o['sellAmount']) / \
+            Decimal(10**util.get_token_decimals(tS))
+        buy_amount = Decimal(o['buyAmount']) / \
+            Decimal(10**util.get_token_decimals(tB))
         if buy_amount != 0:
             total_amounts[tB] += buy_amount
             total_amounts[tS] += sell_amount
 
-            sell_limits_amounts[tS].append((sell_amount / buy_amount, sell_amount))
+            sell_limits_amounts[tS].append(
+                (sell_amount / buy_amount, sell_amount))
 
     # Skip, if no orders for given token pair.
     if len(sell_limits_amounts) == 0:
@@ -81,8 +84,10 @@ def generate_plot(t1: str,
     def corner(f):
         return [f - eps_corner, f, f + eps_corner]
     xrates = np.clip(
-        sum([corner(float(s[0] / fee_multiplier)) for s in sell_limits_amounts[t1]], [])
-        + sum([corner(float(fee_multiplier / s[0])) for s in sell_limits_amounts[t2]], []),
+        sum([corner(float(s[0] / fee_multiplier))
+             for s in sell_limits_amounts[t1]], [])
+        + sum([corner(float(fee_multiplier / s[0]))
+               for s in sell_limits_amounts[t2]], []),
         xrate_LB,
         xrate_UB
     )
@@ -95,7 +100,8 @@ def generate_plot(t1: str,
     t2_name = util.get_token_name(t2)
 
     # Compute cumulated sell/buy amounts on token pair per xrate sample point.
-    cumulated_sell_amounts = {t: np.zeros(len(xrates)) for t in [t1_name, t2_name]}
+    cumulated_sell_amounts = {t: np.zeros(len(xrates)) for t in [
+        t1_name, t2_name]}
 
     for (limit, sell_amount) in sell_limits_amounts[t1]:
         _executable = np.where(xrates <= limit / fee_multiplier, 1, 0)
@@ -154,12 +160,19 @@ if __name__ == "__main__":
         help="Show the output picture in the browser.")
 
     parser.add_argument(
+        '--network',
+        dest='network',
+        type=str,
+        help="Choose one network (mainnet or rinkeby)")
+
+    parser.add_argument(
         '--no-show',
         dest='show',
         action='store_false',
         help="Do not show the output picture in the browser.")
 
     parser.set_defaults(show=True)
+    parser.set_defaults(network='mainnet')
 
     args = parser.parse_args()
 
@@ -171,7 +184,7 @@ if __name__ == "__main__":
     else:
         # Get instance from blockchain.
         output_dir = './'
-        inst = util.read_instance_from_blockchain()
+        inst = util.read_instance_from_blockchain(args.network)
 
     # Get token IDs.
     t1 = util.get_token_ID(args.t1)

--- a/plot_orderbook_tokenpair.py
+++ b/plot_orderbook_tokenpair.py
@@ -161,8 +161,9 @@ if __name__ == "__main__":
 
     parser.add_argument(
         '--network',
-        dest='network',
         type=str,
+        choices=['mainnet', 'rinkeby'],
+        default='mainnet',
         help="Choose one network (mainnet or rinkeby)")
 
     parser.add_argument(
@@ -172,7 +173,6 @@ if __name__ == "__main__":
         help="Do not show the output picture in the browser.")
 
     parser.set_defaults(show=True)
-    parser.set_defaults(network='mainnet')
 
     args = parser.parse_args()
 

--- a/plot_solution_graph.py
+++ b/plot_solution_graph.py
@@ -75,7 +75,8 @@ def generate_plot(nr_orders_tokenpair: Dict[EDGE_TYPE, int],
                       util.decimal_to_str(token_amounts_bought.get(t)))
                    for t in tokens}
 
-    edge_weights = {tp: v for (tp, v) in trading_volume_tokenpairs.items() if v > 0}
+    edge_weights = {tp: v for (
+        tp, v) in trading_volume_tokenpairs.items() if v > 0}
 
     edge_hovers = {(t1, t2): "=== %s/%s ===<br>"
                    "exchange rate : %s %s/%s <> %s %s/%s<br>"
@@ -87,9 +88,12 @@ def generate_plot(nr_orders_tokenpair: Dict[EDGE_TYPE, int],
                       util.decimal_to_str(xrates.get((t2, t1))), t1, t2,
                       (nr_exec_orders_tokenpair.get((t1, t2), 0)
                        + nr_exec_orders_tokenpair.get((t2, t1), 0)),
-                      t1, util.decimal_to_str(tokenpair_amounts_sold.get((t1, t2), Decimal('0'))),
-                      t1, util.decimal_to_str(tokenpair_amounts_bought.get((t1, t2), Decimal('0'))),
-                      t2, util.decimal_to_str(tokenpair_amounts_sold.get((t2, t1), Decimal('0'))),
+                      t1, util.decimal_to_str(
+                          tokenpair_amounts_sold.get((t1, t2), Decimal('0'))),
+                      t1, util.decimal_to_str(
+                          tokenpair_amounts_bought.get((t1, t2), Decimal('0'))),
+                      t2, util.decimal_to_str(
+                          tokenpair_amounts_sold.get((t2, t1), Decimal('0'))),
                       t2, util.decimal_to_str(tokenpair_amounts_bought.get((t2, t1), Decimal('0'))))
                    for (t1, t2) in tokenpairs}
 
@@ -158,7 +162,8 @@ if __name__ == "__main__":
 
     logging.info("=== TOKEN PRICES ===")
     for t, p in token_prices.items():
-        logging.info("%5s : %14s" % (t, util.decimal_to_str(token_prices.get(t))))
+        logging.info("%5s : %14s" %
+                     (t, util.decimal_to_str(token_prices.get(t))))
 
     logging.info("=== EXECUTED ORDERS ===")
     for idx, o in enumerate(inst['orders']):
@@ -191,10 +196,13 @@ if __name__ == "__main__":
                (nr_exec_orders_tokenpair.get((t1, t2), 0)
                 + nr_exec_orders_tokenpair.get((t2, t1), 0)),
                t1,
-               util.decimal_to_str(tokenpair_amounts_sold.get((t1, t2), Decimal('0'))),
-               util.decimal_to_str(tokenpair_amounts_bought.get((t1, t2), Decimal('0'))),
+               util.decimal_to_str(
+                   tokenpair_amounts_sold.get((t1, t2), Decimal('0'))),
+               util.decimal_to_str(
+                   tokenpair_amounts_bought.get((t1, t2), Decimal('0'))),
                t2,
-               util.decimal_to_str(tokenpair_amounts_sold.get((t2, t1), Decimal('0'))),
+               util.decimal_to_str(
+                   tokenpair_amounts_sold.get((t2, t1), Decimal('0'))),
                util.decimal_to_str(tokenpair_amounts_bought.get((t2, t1), Decimal('0')))))
 
     # Plot.

--- a/util.py
+++ b/util.py
@@ -8,13 +8,39 @@ from typing import List, Dict, Tuple
 from collections import OrderedDict
 from decimal import Decimal
 
-from TokenInfo import TOKEN_NAMES, TOKEN_DECIMALS
+from TokenInfo import get_token_data
 
 EDGE_TYPE = Tuple[str, str]
 NODE_TYPE = str
 
 # Set float precision (used for string representation).
 FLOAT_PREC = Decimal('1e-6')
+
+
+def get_TOKEN_NAMES():
+    data = get_token_data()
+    token_names = []
+    for token in data:
+        token_names.append(
+            ' "T' + str(token['id']).zfill(4)+'":"' + token['symbol'] + '"')
+    jsonstring = '{ '+','.join(token_names) + ' }'
+    TOKEN_NAMES = json.loads(jsonstring)
+    return TOKEN_NAMES
+
+
+def get_TOKEN_DECIMALS():
+    data = get_token_data()
+    token_decimals = []
+    for token in data:
+        token_decimals.append(
+            ' "T' + str(token['id']).zfill(4)+'":' + str(token['decimals']) + '')
+    jsonstring = '{ '+','.join(token_decimals) + ' }'
+    TOKEN_DECIMALS = json.loads(jsonstring)
+    return TOKEN_DECIMALS
+
+
+TOKEN_DECIMALS = get_TOKEN_DECIMALS()
+TOKEN_NAMES = get_TOKEN_NAMES()
 
 
 class LevelFilter(object):
@@ -104,7 +130,7 @@ def read_instance_from_file(instance_file: str) -> Dict:
         raise
 
 
-def read_instance_from_blockchain() -> Dict:
+def read_instance_from_blockchain(network='mainnet') -> Dict:
     """Read data directly from blockchain.
 
     Returns:
@@ -114,10 +140,10 @@ def read_instance_from_blockchain() -> Dict:
     import contract_reader
 
     # Get ID of current batch.
-    batch_id = contract_reader.get_current_batch_id()
+    batch_id = contract_reader.get_current_batch_id(network)
 
     # Read all orders.
-    orders = contract_reader.get_current_orderbook()
+    orders = contract_reader.get_current_orderbook(network)
 
     # Extract set of participating tokens from orders.
     tokens = sorted(
@@ -125,7 +151,7 @@ def read_instance_from_blockchain() -> Dict:
     ref_token = tokens[0]
 
     # Init accounts.
-    accounts = contract_reader.get_account_balances(tokens, orders)
+    accounts = contract_reader.get_account_balances(tokens, orders, network)
 
     inst = {'tokens': tokens,
             'refToken': ref_token,


### PR DESCRIPTION
closes #4 

First draft that:

- enables a --network flag to read data from rinkeby and mainnet
- gets token information from dex-js repo

I am very unsure about the best option to pass the network information to the functions get_token_data and to the contract initialization. In other languages, I would have created the contract object once in the main thread and then passed it down to the helper functions.

Should I do all this refactoring or should I just keep it like that and do the further refactoring in another PR?