### PR TITLE
Fix trivial solution plot

### DIFF
--- a/plot_solution_graph.py
+++ b/plot_solution_graph.py
@@ -8,7 +8,7 @@ Example call:
 import os
 import argparse
 import logging
-from typing import Dict
+from typing import List, Dict
 from decimal import Decimal
 
 from plot_utils import plot_network
@@ -16,19 +16,21 @@ import util
 from util import EDGE_TYPE, NODE_TYPE
 
 
-def generate_plot(nr_orders_tokenpair: Dict[EDGE_TYPE, int],
-                  nr_exec_orders_tokenpair: Dict[EDGE_TYPE, int],
-                  token_prices: Dict[NODE_TYPE, Decimal],
-                  token_amounts_sold: Dict[NODE_TYPE, Decimal],
-                  token_amounts_bought: Dict[NODE_TYPE, Decimal],
-                  tokenpair_amounts_sold: Dict[EDGE_TYPE, Decimal],
-                  tokenpair_amounts_bought: Dict[EDGE_TYPE, Decimal],
-                  output_dir: str = './',
-                  ipython: bool = False,
-                  **kwargs):
+def generate_plot(
+        tokens: List[NODE_TYPE],
+        nr_exec_orders_tokenpair: Dict[EDGE_TYPE, int],
+        token_prices: Dict[NODE_TYPE, Decimal],
+        token_amounts_sold: Dict[NODE_TYPE, Decimal],
+        token_amounts_bought: Dict[NODE_TYPE, Decimal],
+        tokenpair_amounts_sold: Dict[EDGE_TYPE, Decimal],
+        tokenpair_amounts_bought: Dict[EDGE_TYPE, Decimal],
+        output_dir: str = './',
+        ipython: bool = False,
+        **kwargs):
     """Generate a token-order-graph plot using plotly.
 
     Args:
+        tokens: List of token names.
         nr_orders_tokenpair: Dict of token pairs => number of orders.
         nr_exec_orders_tokenpair: Dict of token pairs => number of executed orders.
         token_prices: Dict of tokens => token price.
@@ -43,8 +45,7 @@ def generate_plot(nr_orders_tokenpair: Dict[EDGE_TYPE, int],
 
     """
     # Extract set of tokens and token pairs.
-    tokenpairs = nr_orders_tokenpair.keys()
-    tokens = sorted(list(set(sum(tokenpairs, ()))))
+    tokenpairs = nr_exec_orders_tokenpair.keys()
 
     trading_volume_tokens = {
         t: (token_amounts_sold.get(t, 0) * token_prices.get(t, 0)
@@ -140,6 +141,9 @@ if __name__ == "__main__":
     # Read input JSON.
     inst = util.read_instance_from_file(args.jsonFile)
 
+    # Get list of tokens.
+    tokens = util.get_tokens(inst['tokens'])
+
     # Get token prices (denominated in token specified).
     assert 'prices' in inst
     token_prices = util.get_token_prices(inst['prices'])
@@ -207,7 +211,7 @@ if __name__ == "__main__":
 
     # Plot.
     generate_plot(
-        nr_orders_tokenpair,
+        tokens,
         nr_exec_orders_tokenpair,
         token_prices,
         token_amounts_sold,

--- a/plot_utils.py
+++ b/plot_utils.py
@@ -89,6 +89,7 @@ def plot_network(nodes: List[NODE_TYPE],
         hoverinfo='text',
         marker=go.scatter.Marker(
             size=[node_weights[nID] for nID in nodes],
+            sizemin=wmin,
             showscale=False,
             colorscale='Reds',
             reversescale=False,

--- a/plot_utils.py
+++ b/plot_utils.py
@@ -107,7 +107,7 @@ def plot_network(nodes: List[NODE_TYPE],
 
     else:
         # Scale edge weights to some interval.
-        wL, wU = (1., 20.)
+        wL, wU = (2., 20.)
         if edge_weights is None:
             edge_weights = {}
         elif all(math.isnan(w) for w in edge_weights.values()):

--- a/plot_utils.py
+++ b/plot_utils.py
@@ -61,15 +61,16 @@ def plot_network(nodes: List[NODE_TYPE],
     node_weights = {nID: node_weights[nID]
                     if nID in node_weights else wmin for nID in nodes}
 
-    if max(node_weights.values()) > wmax:
-        node_weights = {nID: node_weights[nID] / max(node_weights.values()) * wmax
-                        for nID in nodes}
+    if node_weights:
+        if max(node_weights.values()) > wmax:
+            node_weights = {nID: node_weights[nID] / max(node_weights.values()) * wmax
+                            for nID in nodes}
 
-    if min(node_weights.values()) < wmin:
-        node_weights = {nID: wmax - (wmax - node_weights[nID]) / (wmax - min(node_weights.values())) * (wmax - wmin)
-                        for nID in nodes}
+        if min(node_weights.values()) < wmin:
+            node_weights = {nID: wmax - (wmax - node_weights[nID]) / (wmax - min(node_weights.values())) * (wmax - wmin)
+                            for nID in nodes}
 
-    assert min(node_weights.values()) >= wmin and max(node_weights.values()) <= wmax
+        assert min(node_weights.values()) >= wmin and max(node_weights.values()) <= wmax
 
     # Init node hovers, if required.
     node_hovers = {nID: node_hovers[nID]

--- a/util.py
+++ b/util.py
@@ -4,7 +4,7 @@
 import sys
 import logging
 import json
-from typing import List, Dict, Tuple
+from typing import List, Dict, Tuple, Union
 from collections import OrderedDict
 from decimal import Decimal, ROUND_UP
 
@@ -282,6 +282,22 @@ def get_token_prices(prices: Dict[str, str]) -> Dict[str, Decimal]:
     """
     return {get_token_name(t): Decimal(p) / Decimal(10**(36 - get_token_decimals(t)))
             for t, p in prices.items() if p is not None}
+
+
+def get_tokens(tokens: Union[Dict[NODE_TYPE, Dict], List[NODE_TYPE]]) -> List[NODE_TYPE]:
+    """Get list of tokens by their names.
+
+    Args:
+        tokens: List or dict of tokens.
+
+    Returns:
+        List with all token names.
+
+    """
+    if isinstance(tokens, dict):
+        tokens = tokens.keys()
+
+    return [get_token_name(t) for t in tokens]
 
 
 def get_order_amount_scaled(amount: Decimal, token_ID: str):


### PR DESCRIPTION
This PR fixes the solution plot of the trivial solution to crash.

Previously, the solution graph contained all tokens for which orders were placed in the instance. These orders were carried through to the solution JSON, even if not executed. Hence, there was always a set of tokens to be shown.

This has changed recently since we only write executed orders to the solution JSON. Now, for trivial solutions, the plot crashed because the set of tokens had been empty.

This PR changes the solution plot so that it always shows all tokens given in the instance/solution file. If nothing is traded, the graph simply contains no edges.

*Test:*
Run `python plot_solution_graph.py [JSONFILE]` with a trivial solution result JSON with and without this PR (e.g., this one: https://gnosis-dev-dfusion.s3.amazonaws.com/data/mainnet/fallback-solver/results/2020-04-06/instance_5287234_2020-04-06T10%3A56%3A13.000134426%2B00%3A00/06_solution_int_valid.json)