### PR TITLE
Make log-levels configurable in plot_{order|solution}_graph.py

### DIFF
--- a/plot_order_graph.py
+++ b/plot_order_graph.py
@@ -75,8 +75,6 @@ def generate_plot(nr_orders_tokenpair: Dict[EDGE_TYPE, int],
 if __name__ == "__main__":
     """Main function."""
 
-    util.configure_logger(logging.INFO)
-
     # Process command line arguments.
     parser = argparse.ArgumentParser(
         description='Input file and output directory parser.')
@@ -93,7 +91,16 @@ if __name__ == "__main__":
         default='mainnet',
         help="Choose one network (mainnet or rinkeby)")
 
+    parser.add_argument(
+        '--logging',
+        type=str.upper,
+        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
+        default='INFO',
+        help="Logging level.")
+
     args = parser.parse_args()
+
+    util.configure_logger(getattr(logging, args.logging))
 
     if args.jsonFile is not None:
         # Read input JSON.

--- a/plot_solution_graph.py
+++ b/plot_solution_graph.py
@@ -117,8 +117,6 @@ def generate_plot(
 if __name__ == "__main__":
     """Main function."""
 
-    util.configure_logger(logging.INFO)
-
     # Process command line arguments.
     parser = argparse.ArgumentParser(
         description='Input file and output directory parser.')
@@ -133,7 +131,16 @@ if __name__ == "__main__":
         type=str,
         help="A token name used for denomination of the prices.")
 
+    parser.add_argument(
+        '--logging',
+        type=str.upper,
+        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
+        default='INFO',
+        help="Logging level.")
+
     args = parser.parse_args()
+
+    util.configure_logger(getattr(logging, args.logging))
 
     assert os.path.isfile(args.jsonFile)
     output_dir = os.path.dirname(args.jsonFile)


### PR DESCRIPTION
The title says it all.

Test plan:
Try
```python plot_solution_graph.py data/dfusion_solution.json --logging warning```
vs
```python plot_solution_graph.py data/dfusion_solution.json --logging info```

closes #13 